### PR TITLE
fix double processing of completed and canceled events. 

### DIFF
--- a/Controller/StatusController.php
+++ b/Controller/StatusController.php
@@ -67,18 +67,18 @@ class StatusController extends Controller
 
                         $event = new PaymentEvent($payment);
                         $dispatcher->dispatch(AntQaPaymentEvents::PAYMENT_STATUS_UPDATE, $event);
-                    }
 
-                    if ($result->order->status === Payment::STATUS_CANCELED) {
-                        //payment canceled - eg. notify user?
-                        $event = new PaymentEvent($payment);
-                        $dispatcher->dispatch(AntQaPaymentEvents::PAYMENT_CANCELED, $event);
-                    }
+                        if ($result->order->status === Payment::STATUS_CANCELED) {
+                            //payment canceled - eg. notify user?
+                            $event = new PaymentEvent($payment);
+                            $dispatcher->dispatch(AntQaPaymentEvents::PAYMENT_CANCELED, $event);
+                        }
 
-                    if ($result->order->status === Payment::STATUS_COMPLETED) {
-                        //process payment action - eg. add user point?
-                        $event = new PaymentEvent($payment);
-                        $dispatcher->dispatch(AntQaPaymentEvents::PAYMENT_COMPLETED, $event);
+                        if ($result->order->status === Payment::STATUS_COMPLETED) {
+                            //process payment action - eg. add user point?
+                            $event = new PaymentEvent($payment);
+                            $dispatcher->dispatch(AntQaPaymentEvents::PAYMENT_COMPLETED, $event);
+                        }
                     }
                 }
 


### PR DESCRIPTION
(for anty multiple responses from payu, events should be processed only when database status is different)
